### PR TITLE
Replace view with reshape in loss function

### DIFF
--- a/ATNLPpt/ATNLPpt_prediction.py
+++ b/ATNLPpt/ATNLPpt_prediction.py
@@ -332,8 +332,8 @@ def loss_function(logits: torch.Tensor, targets: torch.Tensor, padMask: torch.Te
 		"""Cross-entropy loss over flattened B1*L dimension with PAD masked out."""
 		# targets: (B, L, C) one-hot; convert to indices
 		targets_idx = targets			  # (B, L)
-		logits = logits.view(-1, logits.size(-1))			 # (B*L, C)
-		targets_idx = targets_idx.view(-1)					# (B*L)
+		logits = logits.reshape(-1, logits.size(-1))			 # (B*L, C)
+		targets_idx = targets_idx.reshape(-1)					# (B*L)
 		loss = F.cross_entropy(logits, targets_idx, ignore_index=NLPpadTokenID)
 	return loss
 	


### PR DESCRIPTION
## Summary
- use `reshape` instead of `view` for logits and target indices in `loss_function`

## Testing
- `python ATNLPpt/ANNpt_main.py` (fails: ModuleNotFoundError: No module named 'GPUtil')

------
https://chatgpt.com/codex/tasks/task_e_68a1568e20c48324aecb356f2a6a981e